### PR TITLE
Fix PHPStan errors in GenerateNamesWithModelJob

### DIFF
--- a/app/Jobs/GenerateNamesWithModelJob.php
+++ b/app/Jobs/GenerateNamesWithModelJob.php
@@ -135,9 +135,9 @@ class GenerateNamesWithModelJob implements ShouldQueue
             // Cache the results for the coordinator to collect
             $resultData = [
                 'model_id' => $this->modelId,
-                'results' => is_array($results) ? $results : [$results],
+                'results' => $results,
                 'execution_time_ms' => $executionTime,
-                'names_generated' => is_array($results) ? count($results) : 1,
+                'names_generated' => count($results),
                 'status' => 'completed',
                 'completed_at' => now()->toISOString(),
             ];


### PR DESCRIPTION
## Summary

Fixed 2 PHPStan static analysis errors in `GenerateNamesWithModelJob.php` by removing redundant `is_array()` checks.

## Changes Made

- Removed redundant `is_array()` check on line 138 for `$results` variable
- Removed redundant `is_array()` check on line 140 for `$results` variable

## Rationale

The `parseResponse()` method has a return type declaration of `array<int, string>`, which guarantees that `$results` is always an array. PHPStan detected that the conditional checks were unnecessary since the type system already enforces this constraint.

## Testing

- ✓ PHPStan analysis passes with zero errors
- ✓ All code formatting maintained with Laravel Pint
- ✓ No functional changes to the code behavior

## Before
```php
'results' => is_array($results) ? $results : [$results],
'names_generated' => is_array($results) ? count($results) : 1,
```

## After
```php
'results' => $results,
'names_generated' => count($results),
```